### PR TITLE
Add Android build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Android APK
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ANDROID_HOME: /usr/lib/android-sdk
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 'stable'
+          cache: true
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Accept licenses
+        run: yes | sdkmanager --licenses
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Build release APK
+        run: flutter build apk --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ We welcome contributions from the community! To contribute, please follow these 
  2.  Create a new branch and make your changes.
  3.  Test your changes thoroughly.
  4.   Submit a pull request with a **clear description** of your changes
+## Continuous Integration
+This project uses GitHub Actions to build the Android application on every push and pull request. The generated APK is available in the workflow artifacts.
+
 ## More Information about Digital Stethoscope app - Mboathoscope
 ### Site Map
 The contents in this project follow the following structure:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds release APK and uploads artifact
- document new CI build process in README

## Testing
- `flutter --version` *(fails: command not found)*
- `./android/gradlew assembleRelease` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68800f39315483278c028b9e933ff920