### PR TITLE
Add GitHub CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build APK
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: build/app/outputs/flutter-apk/app-release.apk

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ The high cost of stethoscopes is a major obstacle for healthcare workers in low-
    flutter pub get
    ```
 3. Run the app
-	 ```
+       ```
    flutter run
-   ``` 
+   ```
+4. Automated build via GitHub Actions. Each push builds an APK, available from the workflow run artifacts.
 ## Contributing
 
 We welcome contributions from the community! To contribute, please follow these steps:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Android APK on pushes and PRs
- mention new automated build in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800f39315483278c028b9e933ff920